### PR TITLE
feat(auth): add protected /users/me endpoint

### DIFF
--- a/backend/security.py
+++ b/backend/security.py
@@ -14,3 +14,20 @@ def create_access_token(data: dict):
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
+
+def verify_token(token: str):
+    try: 
+        # Decode the token using your secret key and algorithm
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        
+        # The user's email is stored in the "sub" (subject) claim
+        email: str = payload.get("sub")
+        
+        if email is None:
+            # If the "sub" claim is missing, the token is invalid
+            return None
+            
+        return email
+    
+    except JWTError:
+        return None


### PR DESCRIPTION
- API Security:
> - Built a reusable `get_current_user` dependency to protect API endpoints by validating JWT bearer tokens.
> - Implemented the final `/users/me` protected endpoint to test and confirm the authentication system is working correctly.
- Final Testing & Debugging:
> - Successfully tested the end-to-end flow for both OTP and Google logins against a protected resource.
> - Resolved an `AttributeError` by correctly handling the `HTTPAuthorizationCredentials` object returned by FastAPI's `HTTPBearer` scheme.